### PR TITLE
PHP 8.1 warning fix

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -26,7 +26,7 @@ class Middleware
 
     private function parseHttpLocale(Request $request): string
     {
-        $list = explode(',', $request->server('HTTP_ACCEPT_LANGUAGE'));
+        $list = explode(',', $request->server('HTTP_ACCEPT_LANGUAGE', ''));
 
         $locales = Collection::make($list)
             ->map(function ($locale) {


### PR DESCRIPTION
explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/vendor/orkhanahmadov/laravel-accept-language-middleware/src/Middleware.php on line 29