### PR TITLE
Laravel 8 support in v2 / PHP 8.1 explode warning fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.0', '8.1']
-        laravel-version: ['^9']
+        laravel-version: ['^8', '^9']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.0', '8.1']
-        laravel-version: ['^8.83', '^9']
+        laravel-version: ['^8', '^9']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.0', '8.1']
-        laravel-version: ['^8', '^9']
+        laravel-version: ['^8.83', '^9']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "illuminate/contracts": "^9.0",
-        "illuminate/http": "^9.0",
-        "illuminate/support": "^9.0"
+        "illuminate/contracts": "^8.0|^9.0",
+        "illuminate/http": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "illuminate/contracts": "^8.83|^9.0",
-        "illuminate/http": "^8.83|^9.0",
-        "illuminate/support": "^8.83|^9.0"
+        "illuminate/contracts": "^8.0|^9.0",
+        "illuminate/http": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^6.0|^7.0",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "illuminate/contracts": "^8.0|^9.0",
-        "illuminate/http": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0"
+        "illuminate/contracts": "^8.83|^9.0",
+        "illuminate/http": "^8.83|^9.0",
+        "illuminate/support": "^8.83|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -26,7 +26,7 @@ class Middleware
 
     private function parseHttpLocale(Request $request): string
     {
-        $list = explode(',', $request->server('HTTP_ACCEPT_LANGUAGE'));
+        $list = explode(',', $request->server('HTTP_ACCEPT_LANGUAGE', ''));
 
         $locales = Collection::make($list)
             ->map(function ($locale) {


### PR DESCRIPTION
Laravel 8.x support and fix #4 

warning in PHP 8.1
```
explode(): Passing null to parameter https://github.com/orkhanahmadov/laravel-accept-language-middleware/pull/2 ($string) of type string is deprecated in /var/www/html/vendor/orkhanahmadov/laravel-accept-language-middleware/src/Middleware.php on line 29
```